### PR TITLE
lg5.pred() help file

### DIFF
--- a/R/DENDRO_BASE_FUNCTIONS.R
+++ b/R/DENDRO_BASE_FUNCTIONS.R
@@ -534,13 +534,31 @@ gap2dbh <- function(gap.width, org.dbh, unit = "cm") {
 ###################################################
 # These functions do many things related to the LG5 function (see vignette)
 
-#' Predicts the dbh from doy and a parameter set
+#' Predicts the dbh from doy and a parameter set using a logistic growth function
 #'
-#' @param params Numeric vector of parameter values
+#' @param params Numeric vector of parameter values for logistic growth function
 #' @param doy Integer vector of days of the year
+#' @details The \code{params} argument should be a vector of length 5 of the following parameters:
+#' \tabular{ll}{
+#' \code{K} \tab lower asymptote of dbh \cr
+#' \code{L} \tab upper asymptote of dbh \cr
+#' \code{doy.ip} \tab day of year of inflection point of curve \cr
+#' \code{r} \tab slope of curve at \code{doy.ip} \cr
+#' \code{theta} \tab allows for asymmetical fits by changing the approach of the upper asymptote. When \code{theta = 1} curve is symmetrical\cr
+#' }
 #'
 #' @return Numeric scalar or vector of dbh values
 #' @export
+#'
+#' @examples
+#' K <- 13.2
+#' L <- 13.8
+#' doy.ip <- 200
+#' r <- 0.075
+#' theta <- 2
+#' params <- c(K, L, doy.ip, r, theta)
+#' doy_domain <- seq(from = 100, to = 300)
+#' plot(doy_domain, lg5.pred(params = params, doy = doy_domain), xlab = "Day of year", ylab = "DBH (cm)")
 lg5.pred <- function(params, doy) {
   paras <- names(params) %in% c("L", "K", "doyip", "r", "theta", "a", "b", "alt.a")
   L <- params[1] # min(dbh, na.rm = T)

--- a/man/lg5.pred.Rd
+++ b/man/lg5.pred.Rd
@@ -2,12 +2,12 @@
 % Please edit documentation in R/DENDRO_BASE_FUNCTIONS.R
 \name{lg5.pred}
 \alias{lg5.pred}
-\title{Predicts the dbh from doy and a parameter set}
+\title{Predicts the dbh from doy and a parameter set using a logistic growth function}
 \usage{
 lg5.pred(params, doy)
 }
 \arguments{
-\item{params}{Numeric vector of parameter values}
+\item{params}{Numeric vector of parameter values for logistic growth function}
 
 \item{doy}{Integer vector of days of the year}
 }
@@ -15,5 +15,25 @@ lg5.pred(params, doy)
 Numeric scalar or vector of dbh values
 }
 \description{
-Predicts the dbh from doy and a parameter set
+Predicts the dbh from doy and a parameter set using a logistic growth function
+}
+\details{
+The \code{params} argument should be a vector of length 5 of the following parameters:
+\tabular{ll}{
+\code{K} \tab lower asymptote of dbh \cr
+\code{L} \tab upper asymptote of dbh \cr
+\code{doy.ip} \tab day of year of inflection point of curve \cr
+\code{r} \tab slope of curve at \code{doy.ip} \cr
+\code{theta} \tab allows for asymmetical fits by changing the approach of the upper asymptote. When \code{theta = 1} curve is symmetrical\cr
+}
+}
+\examples{
+K <- 13.2
+L <- 13.8
+doy.ip <- 200
+r <- 0.075
+theta <- 2
+params <- c(K, L, doy.ip, r, theta)
+doy_domain <- seq(from = 100, to = 300)
+plot(doy_domain, lg5.pred(params = params, doy = doy_domain), xlab = "Day of year", ylab = "DBH (cm)")
 }


### PR DESCRIPTION
Hey @seanmcm, hope you've been well. A heads up that your `lg5.pred()` function is not accessible when you load this package. The likely culprit is that the help file for this function was missing `@examples` roxygen2 code. This PR includes two things:

* I added a simple `@examples`. `lg5.pred()` now loads
* I want to use this function in my Ecological Forecasting undergraduate class, so I added documentation about what the 5 parameters mean